### PR TITLE
update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ scipy>=1.7.1
 
 grpcio==1.48.1
 protobuf==3.20.0
+sentencepiece


### PR DESCRIPTION
Update requirements to include sentencepiece. 

Otherwise, using the example code will give
```
ValueError: Couldn't instantiate the backend tokenizer from one of: 
(1) a `tokenizers` library serialization file, 
(2) a slow tokenizer instance to convert or 
(3) an equivalent slow tokenizer class to instantiate and convert. 
You need to have sentencepiece installed to convert a slow tokenizer to a fast one.
```