### PR TITLE
Add OpenLLM support

### DIFF
--- a/alfred/client/client.py
+++ b/alfred/client/client.py
@@ -100,7 +100,7 @@ class Client:
             self.run = self.cache.cached_query(self.run)
 
         self.grpcClient = None
-        if end_point:
+        if end_point and model_type not in ["dummy", "openllm", ]:
             end_point_pieces = end_point.split(":")
             self.end_point_ip, self.end_point_port = (
                 "".join(end_point_pieces[:-1]),
@@ -184,10 +184,8 @@ class Client:
             elif self.model_type == "openllm":
                 from ..fm.openllm import OpenLLMModel
 
-                if self.model is None:
-                    self.model = end_point
-
-                self.model = OpenLLMModel(self.model, **kwargs)
+                base_url = kwargs.get("base_url", end_point)
+                self.model = OpenLLMModel(self.model, base_url=base_url, **kwargs)
             elif self.model_type == "cohere":
                 from ..fm.cohere import CohereModel
 

--- a/alfred/client/client.py
+++ b/alfred/client/client.py
@@ -80,6 +80,7 @@ class Client:
                 "google",
                 "groq",
                 "torch",
+                "openllm",
                 "dummy",
             ], f"Invalid model type: {self.model_type}"
         else:
@@ -180,6 +181,13 @@ class Client:
                 from ..fm.openai import OpenAIModel
 
                 self.model = OpenAIModel(self.model, **kwargs)
+            elif self.model_type == "openllm":
+                from ..fm.openllm import OpenLLMModel
+
+                if self.model is None:
+                    self.model = end_point
+
+                self.model = OpenLLMModel(self.model, **kwargs)
             elif self.model_type == "cohere":
                 from ..fm.cohere import CohereModel
 

--- a/alfred/fm/openllm.py
+++ b/alfred/fm/openllm.py
@@ -1,0 +1,185 @@
+import json
+import logging
+import os
+from typing import Optional, List, Any, Union, Tuple
+
+import PIL.Image
+import torch
+
+from .model import APIAccessFoundationModel
+from .response import CompletionResponse, RankedResponse
+from .utils import colorize_str, retry, encode_image, type_print
+
+logger = logging.getLogger(__name__)
+
+try:
+    import openai
+except ModuleNotFoundError:
+    logger.warning(
+        "OpenAI module not found. Please install it to use the OpenAI model or connect to OpenLLM Server."
+    )
+    raise ModuleNotFoundError(
+        "OpenAI module not found. Please install it to use the OpenAI model or connect to OpenLLM Server."
+    )
+
+from openai._exceptions import (
+    AuthenticationError,
+    APIError,
+    APITimeoutError,
+    RateLimitError,
+    BadRequestError,
+    APIConnectionError,
+    APIStatusError,
+)
+
+
+
+class OpenLLMModel(APIAccessFoundationModel):
+    """
+    A wrapper for the OpenAI API for OpenLLM Models
+
+    This class provides a wrapper for the OpenAI API for generating completions.
+    """
+
+    @retry(
+        num_retries=3,
+        wait_time=0.1,
+        exceptions=(
+            AuthenticationError,
+            APIConnectionError,
+            APITimeoutError,
+            RateLimitError,
+            APIError,
+            BadRequestError,
+            APIStatusError,
+        ),
+    )
+    def _openai_query(
+        self,
+        query: Union[str, List, Tuple],
+        temperature: float = 0.0,
+        max_tokens: int = 64,
+        **kwargs: Any,
+    ) -> str:
+        """
+        Run a single query through the foundation model
+
+        :param query: The prompt to be used for the query
+        :type query: Union[str, List]
+        :param temperature: The temperature of the model
+        :type temperature: float
+        :param max_tokens: The maximum number of tokens to be returned
+        :type max_tokens: int
+        :param kwargs: Additional keyword arguments
+        :type kwargs: Any
+        :return: The generated completion
+        :rtype: str
+        """
+        chat = kwargs.get("chat", False)
+        openai_api_key = kwargs.get("openai_api_key", None)
+        if openai_api_key is not None:
+            openai.api_key = openai_api_key
+
+        if chat:
+            return self.openai_client.chat.completions.create(
+                model=self.model_string,
+                messages=query,
+                max_tokens=max_tokens,
+                stop=None,
+                temperature=temperature,
+                stream=True,
+            )
+        else:
+            query = [{"role": "user", "content": query}]
+            response = self.openai_client.chat.completions.create(
+                messages=query,
+                model=self.model_string,
+                temperature=temperature,
+                max_tokens=max_tokens,
+            )
+            return response.choices[0].message.content
+
+    @retry(
+        num_retries=3,
+        wait_time=0.1,
+        exceptions=(
+            AuthenticationError,
+            APIConnectionError,
+            APITimeoutError,
+            RateLimitError,
+            APIError,
+            BadRequestError,
+            APIStatusError,
+        ),
+    )
+
+    def __init__(
+        self, model_string: str = "", api_key: Optional[str] = None, **kwargs: Any
+    ):
+        """
+        Initialize the OpenAI API wrapper.
+
+        :param model_string: The model to be used for generating completions.
+        :type model_string: str
+        :param api_key: The API key to be used for the OpenAI API.
+        :type api_key: Optional[str]
+        """
+        base_url = kwargs.get("base_url", None)
+        if not api_key:
+            api_key = "na"
+        self.openai_client = openai.OpenAI(base_url=base_url if base_url else model_string)
+        super().__init__(model_string, {"api_key": openai.api_key})
+
+    def _generate_batch(
+        self,
+        batch_instance: Union[List[str], Tuple],
+        **kwargs,
+    ) -> List[CompletionResponse]:
+        """
+        Generate completions for a batch of prompts using the OpenAI API.
+
+        This function generates completions for a batch of prompts using the OpenAI API.
+        The generated completions are returned in a list of `CompletionResponse` objects.
+
+        :param batch_instance: A list of prompts for which to generate completions.
+        :type batch_instance: List[str] or List[Tuple]
+        :param kwargs: Additional keyword arguments to pass to the OpenAI API.
+        :type kwargs: Any
+        :return: A list of `CompletionResponse` objects containing the generated completions.
+        :rtype: List[CompletionResponse]
+        """
+        output = []
+        for query in batch_instance:
+            output.append(
+                CompletionResponse(prediction=self._openai_query(query, **kwargs))
+            )
+        return output
+
+    def _score_batch(
+        self,
+        batch_instance: Union[List[Tuple[str, str]], List[str]],
+        scoring_instruction: str = "Instruction: Given the query, choose your answer from [[label_space]]:\nQuery:\n",
+        **kwargs,
+    ) -> List[RankedResponse]:
+        """
+        Tentative solution for scoring candidates.
+
+        :param batch_instance: A list of prompts for which to generate candidate preferences.
+        :type batch_instance: List[str] or List[Tuple]
+        :param scoring_instruction: The instruction prompt for scoring
+        :type scoring_instruction: str
+        """
+        output = []
+        for query in batch_instance:
+            _scoring_prompt = (
+                scoring_instruction.replace(
+                    "[[label_space]]", ",".join(query.candidates)
+                )
+                + query.prompt
+            )
+            output.append(
+                RankedResponse(
+                    prediction=self._openai_query(_scoring_prompt, **kwargs), scores={}
+                )
+            )
+        return output

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@ A full list of `Alfred` project modules.
         - [Model](alfred/fm/model.md#model)
         - [Onnx](alfred/fm/onnx.md#onnx)
         - [Openai](alfred/fm/openai.md#openai)
+        - [Openllm](alfred/fm/openllm.md#openllm)
         - [Query](alfred/fm/query/index.md#query)
             - [CompletionQuery](alfred/fm/query/completion_query.md#completionquery)
             - [Query](alfred/fm/query/query.md#query)

--- a/docs/alfred/client/client.md
+++ b/docs/alfred/client/client.md
@@ -44,7 +44,7 @@ class Client:
 
 ### Client().__call__
 
-[Show source in client.py:313](../../../alfred/client/client.py#L313)
+[Show source in client.py:319](../../../alfred/client/client.py#L319)
 
 __call__() function to run the model on the queries.
 Equivalent to run() function.
@@ -71,7 +71,7 @@ def __call__(
 
 ### Client().calibrate
 
-[Show source in client.py:329](../../../alfred/client/client.py#L329)
+[Show source in client.py:335](../../../alfred/client/client.py#L335)
 
 calibrate are used to calibrate foundation models contextually given the template.
 A voter class may be passed to calibrate the model with a specific voter.
@@ -115,7 +115,7 @@ def calibrate(
 
 ### Client().chat
 
-[Show source in client.py:427](../../../alfred/client/client.py#L427)
+[Show source in client.py:433](../../../alfred/client/client.py#L433)
 
 Chat with the model APIs.
 Currently, Alfred supports Chat APIs from Anthropic and OpenAI
@@ -133,7 +133,7 @@ def chat(self, log_save_path: Optional[str] = None, **kwargs: Any): ...
 
 ### Client().encode
 
-[Show source in client.py:401](../../../alfred/client/client.py#L401)
+[Show source in client.py:407](../../../alfred/client/client.py#L407)
 
 embed() function to embed the queries.
 
@@ -155,7 +155,7 @@ def encode(
 
 ### Client().generate
 
-[Show source in client.py:272](../../../alfred/client/client.py#L272)
+[Show source in client.py:278](../../../alfred/client/client.py#L278)
 
 Wrapper function to generate the response(s) from the model. (For completion)
 
@@ -183,7 +183,7 @@ def generate(
 
 ### Client().remote_run
 
-[Show source in client.py:246](../../../alfred/client/client.py#L246)
+[Show source in client.py:252](../../../alfred/client/client.py#L252)
 
 Wrapper function for running the model on the queries thru a gRPC Server.
 
@@ -209,7 +209,7 @@ def remote_run(
 
 ### Client().run
 
-[Show source in client.py:226](../../../alfred/client/client.py#L226)
+[Show source in client.py:232](../../../alfred/client/client.py#L232)
 
 Run the model on the queries.
 
@@ -235,7 +235,7 @@ def run(
 
 ### Client().score
 
-[Show source in client.py:289](../../../alfred/client/client.py#L289)
+[Show source in client.py:295](../../../alfred/client/client.py#L295)
 
 Wrapper function to score the response(s) from the model. (For ranking)
 

--- a/docs/alfred/fm/index.md
+++ b/docs/alfred/fm/index.md
@@ -22,6 +22,7 @@
 - [Model](./model.md)
 - [Onnx](./onnx.md)
 - [Openai](./openai.md)
+- [Openllm](./openllm.md)
 - [Query](query/index.md)
 - [Remote](remote/index.md)
 - [Response](response/index.md)


### PR DESCRIPTION
Adding support for OpenLLM servers (https://github.com/bentoml/OpenLLM)

Example Usage:
```
from alfred import Client

openllm = Client(model_type="openllm", model="meta-llama/Meta-Llama-3.1-8B-Instruct", end_point="http://llmserver:3700/v1")
```